### PR TITLE
Added InitializeTarget check to allow to provide target RichTextBox explicitly

### DIFF
--- a/NLog.Windows.Forms/RichTextBoxTarget.cs
+++ b/NLog.Windows.Forms/RichTextBoxTarget.cs
@@ -209,6 +209,12 @@ namespace NLog.Windows.Forms
         /// </summary>
         protected override void InitializeTarget()
         {
+			if (TargetRichTextBox != null && TargetForm != null) 
+			{
+				CreatedForm = false;
+				return;
+			}
+
             if (FormName == null)
             {
                 FormName = "NLogForm" + Guid.NewGuid().ToString("N");

--- a/NLog.Windows.Forms/RichTextBoxTarget.cs
+++ b/NLog.Windows.Forms/RichTextBoxTarget.cs
@@ -209,11 +209,11 @@ namespace NLog.Windows.Forms
         /// </summary>
         protected override void InitializeTarget()
         {
-			if (TargetRichTextBox != null && TargetForm != null) 
-			{
-				CreatedForm = false;
-				return;
-			}
+            if (TargetRichTextBox != null && TargetForm != null) 
+            {
+                CreatedForm = false;
+                return;
+            }
 
             if (FormName == null)
             {


### PR DESCRIPTION
Had a need in my project to add log target in a control constructor - which means there is no form yet at the moment of RichTextBox target creation. Basically, I wasn't able to utilize RichTextBoxTarget because the target RichTextBox was not in the tree of main Form controls at the moment of logging initialization

This change, I think, would be a good possible way to solve that issue.

I would have not null-checked TargetForm, but I'm not sure whether it's used elsewhere