### PR TITLE
Fix for a RTB-target initialization bug

### DIFF
--- a/NLog.Windows.Forms/RichTextBoxTarget.cs
+++ b/NLog.Windows.Forms/RichTextBoxTarget.cs
@@ -497,7 +497,7 @@ namespace NLog.Windows.Forms
                 }
 
                 targetControl = FormHelper.FindControl<RichTextBox>(ControlName, openFormByName);
-                if (TargetRichTextBox == null)
+                if (targetControl == null)
                 {
                     InternalLogger.Info("Rich text box control '{0}' cannot be found on form '{1}'. Waiting for ReInitializeAllTextboxes.", ControlName, FormName);
                     return;
@@ -782,6 +782,11 @@ namespace NLog.Windows.Forms
         private void SendTheMessageToRichTextBox(string logMessage, RichTextBoxRowColoringRule rule, LogEventInfo logEvent)
         {
             RichTextBox textBox = TargetRichTextBox;
+
+            if (textBox == null)
+            {
+                return;
+            }
 
             int startIndex = textBox.Text.Length;
             textBox.SelectionStart = startIndex;

--- a/NLog.Windows.Forms/RichTextBoxTarget.cs
+++ b/NLog.Windows.Forms/RichTextBoxTarget.cs
@@ -783,11 +783,6 @@ namespace NLog.Windows.Forms
         {
             RichTextBox textBox = TargetRichTextBox;
 
-            if (textBox == null)
-            {
-                return;
-            }
-
             int startIndex = textBox.Text.Length;
             textBox.SelectionStart = startIndex;
             textBox.SelectionBackColor = GetColorFromString(rule.BackgroundColor, textBox.BackColor);


### PR DESCRIPTION
This was lost during refactoring. Now it causes not attaching to existing targets during Initialize() call. So only ReInitializeAllTextboxes works. Sorry for that. We probably need 4.2.1 hotfix release.