### PR TITLE
RichTextBoxTarget: fix problem with logging stored messages during form creation

### DIFF
--- a/NLog.Windows.Forms.Tests/RichTextBoxTargetTests.cs
+++ b/NLog.Windows.Forms.Tests/RichTextBoxTargetTests.cs
@@ -29,6 +29,7 @@ namespace NLog.Windows.Forms.Tests
     {
         private Logger logger = LogManager.GetLogger("NLog.UnitTests.Targets.RichTextBoxTargetTests");
 
+        //Fails locally, see #21
         [Fact]
         public void SimpleRichTextBoxTargetTest()
         {
@@ -82,6 +83,7 @@ namespace NLog.Windows.Forms.Tests
             Assert.True(form.IsDisposed);
         }
 
+        //Fails locally, see #21
         [Fact]
         public void NoColoringTest()
         {
@@ -128,6 +130,7 @@ namespace NLog.Windows.Forms.Tests
             }
         }
 
+        //Fails locally, see #21
         [Fact]
         public void CustomRowColoringTest()
         {
@@ -178,6 +181,7 @@ namespace NLog.Windows.Forms.Tests
             }
         }
 
+        //Fails locally, see #21
         [Fact]
         public void CustomWordRowColoringTest()
         {
@@ -848,7 +852,69 @@ namespace NLog.Windows.Forms.Tests
             }
         }
 
-        
+        private sealed class TestForm : Form
+        {
+            internal readonly RichTextBox rtb;
+            internal TestForm()
+            {
+                this.Name = "MyForm1";
+                //with minimized forms textbox is created with width of 0, so texts get trimmed and result.Contains() fails
+                //form.WindowState = FormWindowState.Minimized; 
+                this.Width = 600;
+                this.rtb = new RichTextBox();
+                rtb.Dock = DockStyle.Fill;
+                rtb.Name = "Control1";
+                this.Controls.Add(rtb);
+
+                RichTextBoxTarget.ReInitializeAllTextboxes(this);
+            }
+        }
+
+        //test for #24
+        [Fact]
+        public void CustomFormReinitializeInConstructor()
+        {
+            var config = new LoggingConfiguration();
+            var target = new RichTextBoxTarget() {
+                FormName = "MyForm1",
+                ControlName = "Control1",
+                UseDefaultRowColoringRules = true,
+                Layout = "${message}",
+                AllowAccessoryFormCreation = false,
+                MaxLines = 10,
+                MessageRetention = RichTextBoxTargetMessageRetentionStrategy.All
+            };
+            LogManager.ThrowExceptions = true;
+            SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
+
+            logger.Trace("No Control");
+            Application.DoEvents();
+
+            Assert.False(target.CreatedForm);
+            Assert.Null(target.TargetForm);
+            Assert.Null(target.TargetRichTextBox);
+
+            using (TestForm form = new TestForm())
+            {
+                
+                form.Show();
+                form.Activate();
+
+                logger.Trace("Has Control");
+                Application.DoEvents();
+                {
+                    Assert.False(target.CreatedForm);
+                    Assert.Same(form, target.TargetForm);
+                    Assert.Same(form.rtb, target.TargetRichTextBox);
+
+                    string result = ExtractRtf(target.TargetRichTextBox);
+
+                    Assert.True(result.Contains(@"No Control"));
+                    Assert.True(result.Contains(@"Has Control"));
+                    Assert.Equal(2 + 1, form.rtb.Lines.Length);  //2 lines + 1 empty
+                }
+            }
+        }
 
         [Fact]
         public void ManualRegisterTestWithRetentionConfigReload()

--- a/NLog.Windows.Forms.Tests/RichTextBoxTargetTests.cs
+++ b/NLog.Windows.Forms.Tests/RichTextBoxTargetTests.cs
@@ -29,7 +29,9 @@ namespace NLog.Windows.Forms.Tests
     {
         private Logger logger = LogManager.GetLogger("NLog.UnitTests.Targets.RichTextBoxTargetTests");
 
-        //Fails locally, see #21
+        /// <remarks>
+        /// Fails locally, see <a href="https://github.com/NLog/NLog.Windows.Forms/issues/21">#21</a>
+        /// </remarks>
         [Fact]
         public void SimpleRichTextBoxTargetTest()
         {
@@ -83,7 +85,9 @@ namespace NLog.Windows.Forms.Tests
             Assert.True(form.IsDisposed);
         }
 
-        //Fails locally, see #21
+        /// <remarks>
+        /// Fails locally, see <a href="https://github.com/NLog/NLog.Windows.Forms/issues/21">#21</a>
+        /// </remarks>
         [Fact]
         public void NoColoringTest()
         {
@@ -130,7 +134,9 @@ namespace NLog.Windows.Forms.Tests
             }
         }
 
-        //Fails locally, see #21
+        /// <remarks>
+        /// Fails locally, see <a href="https://github.com/NLog/NLog.Windows.Forms/issues/21">#21</a>
+        /// </remarks>
         [Fact]
         public void CustomRowColoringTest()
         {
@@ -181,7 +187,9 @@ namespace NLog.Windows.Forms.Tests
             }
         }
 
-        //Fails locally, see #21
+        /// <remarks>
+        /// Fails locally, see <a href="https://github.com/NLog/NLog.Windows.Forms/issues/21">#21</a>
+        /// </remarks>
         [Fact]
         public void CustomWordRowColoringTest()
         {
@@ -870,7 +878,9 @@ namespace NLog.Windows.Forms.Tests
             }
         }
 
-        //test for #24
+        /// <summary>
+        /// a test for <a href="https://github.com/NLog/NLog.Windows.Forms/issues/24">#24</a>
+        /// </summary>
         [Fact]
         public void CustomFormReinitializeInConstructor()
         {

--- a/NLog.Windows.Forms/RichTextBoxTarget.cs
+++ b/NLog.Windows.Forms/RichTextBoxTarget.cs
@@ -737,7 +737,14 @@ namespace NLog.Windows.Forms
             {
                 if (textbox != null && !textbox.IsDisposed)
                 {
-                    textbox.BeginInvoke(new DelSendTheMessageToRichTextBox(SendTheMessageToRichTextBox), logMessage, rule, logEvent);
+                    if (textbox.InvokeRequired)
+                    {
+                        textbox.BeginInvoke(new DelSendTheMessageToRichTextBox(SendTheMessageToRichTextBox), logMessage, rule, logEvent);
+                    }
+                    else
+                    {
+                        SendTheMessageToRichTextBox(logMessage, rule, logEvent);
+                    }
                     return true;
                 }
             }

--- a/TestApplication/Form1.cs
+++ b/TestApplication/Form1.cs
@@ -24,8 +24,8 @@ namespace TestApplication
 
             NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
             Logger.Info("Init");
-            
 
+            RichTextBoxTarget.ReInitializeAllTextboxes(this);
 
             var thread = new Thread(() =>
             {
@@ -48,12 +48,10 @@ namespace TestApplication
             });
             Logger.Info("start thread");
             thread.Start();
-
         }
 
         private void Form1_Load(object sender, EventArgs e)
         {
-            RichTextBoxTarget.ReInitializeAllTextboxes(this);
             RichTextBoxTarget.GetTargetByControl(richTextBox1).LinkClicked += Form1_LinkClicked;
             RichTextBoxTarget.GetTargetByControl(richTextBox2).LinkClicked += Form1_LinkClicked;
         }

--- a/TestApplication/Form1.cs
+++ b/TestApplication/Form1.cs
@@ -24,7 +24,7 @@ namespace TestApplication
 
             NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
             Logger.Info("Init");
-
+            
             RichTextBoxTarget.ReInitializeAllTextboxes(this);
 
             var thread = new Thread(() =>
@@ -48,6 +48,7 @@ namespace TestApplication
             });
             Logger.Info("start thread");
             thread.Start();
+
         }
 
         private void Form1_Load(object sender, EventArgs e)


### PR DESCRIPTION
fixes #24. 
It seems that not issuing BeginInvoke() when it's not needed solves the problem.

Mostly based on answers from 
http://stackoverflow.com/questions/808867/invoke-or-begininvoke-cannot-be-called-on-a-control-until-the-window-handle-has