### PR TITLE
Fix for #27 - calling base.InitializeTarget()

### DIFF
--- a/NLog.Windows.Forms/RichTextBoxTarget.cs
+++ b/NLog.Windows.Forms/RichTextBoxTarget.cs
@@ -433,6 +433,8 @@ namespace NLog.Windows.Forms
         /// </summary>
         protected override void InitializeTarget()
         {
+            base.InitializeTarget();
+
             if (TargetRichTextBox != null)
             {
                 //already initialized by ReInitializeAllTextboxes call


### PR DESCRIPTION
Here's a fix for #27.
I haven't found anything related to calling base.InitializeTarget in the NLog 4.3 description, so I'm not sure if I have to make some other precautions before calling it. But tests are passing, so I think this is OK.