### PR TITLE
Appending To a TextBox control will use .AppendText() instead of just…

### DIFF
--- a/NLog.Windows.Forms/FormControlTarget.cs
+++ b/NLog.Windows.Forms/FormControlTarget.cs
@@ -129,8 +129,11 @@ namespace NLog.Windows.Forms
                 //beginning or end?
                 if (ReverseOrder)
                     control.Text = logMessage + control.Text;
-                else
-                    control.Text += logMessage;
+                else                
+                    if (control is TextBoxBase)
+                        (control as TextBoxBase).AppendText(logMessage);                   
+                    else
+                        control.Text += logMessage;                                   
             }
             else
             {

--- a/NLog.Windows.Forms/FormControlTarget.cs
+++ b/NLog.Windows.Forms/FormControlTarget.cs
@@ -130,10 +130,13 @@ namespace NLog.Windows.Forms
                 if (ReverseOrder)
                     control.Text = logMessage + control.Text;
                 else                
-                    if (control is TextBoxBase)
-                        (control as TextBoxBase).AppendText(logMessage);                   
+                {
+                    var textBoxControl = control as TextBoxBase;
+                    if (textBoxControl != null)
+                        textBoxControl.AppendText(logMessage);                   
                     else
-                        control.Text += logMessage;                                   
+                        control.Text += logMessage; 
+                }                                  
             }
             else
             {


### PR DESCRIPTION
… concatinating with control.Text

This change will cause a textbox being used as a log target to scroll as log messages are added.  We've been using our own build to get this functionality but would love to get it into the official distribution so we can kill our build.