### PR TITLE
Add DetachControl option for manual detaching. Performance tweak for AutoScroll.

### DIFF
--- a/NLog.Windows.Forms/RichTextBoxTarget.cs
+++ b/NLog.Windows.Forms/RichTextBoxTarget.cs
@@ -625,6 +625,15 @@ namespace NLog.Windows.Forms
                 linkClickEvent(this, linkText, logEvent);
             }
         }
+        
+        /// <summary>
+        /// Used to detach the control manually from the target
+        /// </summary>
+        public void DetachControl()
+        {
+            DetachFromControl();
+            lastLoggedTextBoxControl = null;
+        }
 
         /// <summary>
         /// if <see cref="CreatedForm"/> is true, then destroys created form. Resets <see cref="CreatedForm"/>, <see cref="TargetForm"/> and <see cref="TargetRichTextBox"/> to default values

--- a/NLog.Windows.Forms/RichTextBoxTarget.cs
+++ b/NLog.Windows.Forms/RichTextBoxTarget.cs
@@ -77,7 +77,8 @@ namespace NLog.Windows.Forms
         /// (after having <see cref="InitializeTarget"/> called), so such targets are not affected by this method.
         /// </remarks>
         /// <param name="form">a Form to check for RichTextBoxes</param>
-        public static void ReInitializeAllTextboxes(Form form)
+        /// <param name="scrollOnce">Scroll text box to the end only once. use this if you have performance issues when filling the textbox</param>
+        public static void ReInitializeAllTextboxes(Form form, bool scrollOnce = false)
         {
             InternalLogger.Info("Executing ReInitializeAllTextboxes for Form {0}", form);
             foreach (Target target in LogManager.Configuration.AllTargets)
@@ -94,7 +95,7 @@ namespace NLog.Windows.Forms
                             || textboxTarget.TargetRichTextBox != textboxControl
                         )
                         {
-                            textboxTarget.AttachToControl(form, textboxControl);
+                            textboxTarget.AttachToControl(form, textboxControl, scrollOnce);
                         }
                     }
                 }
@@ -554,7 +555,7 @@ namespace NLog.Windows.Forms
                 this.TargetRichTextBox.LinkClicked += TargetRichTextBox_LinkClicked;
             }
 
-            var autoScroll = scrollOnce || AutoScroll; 
+            var autoScroll = !scrollOnce && AutoScroll; 
 
             //OnReattach?
             switch (messageRetention)


### PR DESCRIPTION
We need it to overcome the optimization in some cases.
L 560: if (lastLoggedTextBoxControl != textboxControl)

We use multiple targets, but for the same control. After switching targets the content is not filled again to the control. I added some performance tweak so if the line count is high it would not scroll for each message one by one.