### PR TITLE
Add ToolStripItemTarget.

### DIFF
--- a/NLog.Windows.Forms.Tests/RichTextBoxTargetTests.cs
+++ b/NLog.Windows.Forms.Tests/RichTextBoxTargetTests.cs
@@ -12,6 +12,7 @@ using System.Threading;
 
 namespace NLog.Windows.Forms.Tests
 {
+    [Collection("NLog.Windows.Forms Tests")]
     public class RichTextBoxTargetTests
     {
         private Logger logger = LogManager.GetLogger("NLog.UnitTests.Targets.RichTextBoxTargetTests");

--- a/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
+++ b/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
@@ -33,29 +33,29 @@ namespace NLog.Windows.Forms.Tests
                 };
                 SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
 
-                logger.Fatal("Test");
-                Application.DoEvents();
-                Assert.Equal("Fatal NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text);
+                logger.Fatal("Test");   // Send log
+                Application.DoEvents(); // Do events so invoked method can run.
+                Assert.Equal("Fatal NLog.UnitTests.Targets.ToolStripItemTargetTests Test", getText(testForm,testItem)); // Test if method worked.
                 
                 logger.Error("Foo");
                 Application.DoEvents();
-                Assert.Equal("Error NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
+                Assert.Equal("Error NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", getText(testForm, testItem));
                 
                 logger.Warn("Bar");
                 Application.DoEvents();
-                Assert.Equal("Warn NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
+                Assert.Equal("Warn NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", getText(testForm, testItem));
                 
                 logger.Info("Test");
                 Application.DoEvents();
-                Assert.Equal("Info NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text);
+                Assert.Equal("Info NLog.UnitTests.Targets.ToolStripItemTargetTests Test", getText(testForm, testItem));
                 
                 logger.Debug("Foo");
                 Application.DoEvents();
-                Assert.Equal("Debug NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
+                Assert.Equal("Debug NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", getText(testForm, testItem));
                 
                 logger.Trace("Bar");
                 Application.DoEvents();
-                Assert.Equal("Trace NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
+                Assert.Equal("Trace NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", getText(testForm, testItem));
 
             }
             finally
@@ -66,6 +66,11 @@ namespace NLog.Windows.Forms.Tests
                 }
                 LogManager.Configuration = null;
             }
+        }
+
+        private string getText(Form testForm, ToolStripMenuItem testItem)
+        {
+            return (string)testForm.Invoke((Func<string>)(()=> testItem.Text));
         }
 
         [STAThread]

--- a/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
+++ b/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
@@ -34,28 +34,34 @@ namespace NLog.Windows.Forms.Tests
                 SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
 
                 logger.Fatal("Test");   // Send log
-                Application.DoEvents(); // Do events so invoked method can run.
-                Assert.Equal("Fatal NLog.UnitTests.Targets.ToolStripItemTargetTests Test", getText(testForm,testItem)); // Test if method worked.
+                while (target.IsWaiting()) // Do events until the invoked method is completed.
+                    Application.DoEvents(); 
+                Assert.Equal("Fatal NLog.UnitTests.Targets.ToolStripItemTargetTests Test",testItem.Text); // Test if method worked.
                 
                 logger.Error("Foo");
-                Application.DoEvents();
-                Assert.Equal("Error NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", getText(testForm, testItem));
+                while (target.IsWaiting()) // Do events until the invoked method is completed.
+                    Application.DoEvents();
+                Assert.Equal("Error NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
                 
                 logger.Warn("Bar");
-                Application.DoEvents();
-                Assert.Equal("Warn NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", getText(testForm, testItem));
+                while (target.IsWaiting()) // Do events until the invoked method is completed.
+                    Application.DoEvents();
+                Assert.Equal("Warn NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
                 
                 logger.Info("Test");
-                Application.DoEvents();
-                Assert.Equal("Info NLog.UnitTests.Targets.ToolStripItemTargetTests Test", getText(testForm, testItem));
+                while (target.IsWaiting()) // Do events until the invoked method is completed.
+                    Application.DoEvents();
+                Assert.Equal("Info NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text);
                 
                 logger.Debug("Foo");
-                Application.DoEvents();
-                Assert.Equal("Debug NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", getText(testForm, testItem));
+                while (target.IsWaiting()) // Do events until the invoked method is completed.
+                    Application.DoEvents();
+                Assert.Equal("Debug NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
                 
                 logger.Trace("Bar");
-                Application.DoEvents();
-                Assert.Equal("Trace NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", getText(testForm, testItem));
+                while (target.IsWaiting()) // Do events until the invoked method is completed.
+                    Application.DoEvents();
+                Assert.Equal("Trace NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
 
             }
             finally
@@ -66,11 +72,6 @@ namespace NLog.Windows.Forms.Tests
                 }
                 LogManager.Configuration = null;
             }
-        }
-
-        private string getText(Form testForm, ToolStripMenuItem testItem)
-        {
-            return (string)testForm.Invoke((Func<string>)(()=> testItem.Text));
         }
 
         [STAThread]

--- a/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
+++ b/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
@@ -16,9 +16,10 @@ namespace NLog.Windows.Forms.Tests
         [Fact]
         public void SimpleToolStripItemTargetTest()
         {
+            Form testForm = null;
             try
             {
-                Form testForm = new Form();
+                testForm = new Form();
                 testForm.Name = "Form1";
 
 
@@ -44,20 +45,31 @@ namespace NLog.Windows.Forms.Tests
                 SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
 
                 logger.Fatal("Test");
-                Assert.Equal("FATAL NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text);
+                Application.DoEvents();
+                Assert.Equal("Fatal NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text);
                 logger.Error("Foo");
-                Assert.Equal("ERROR NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
+                Application.DoEvents();
+                Assert.Equal("Error NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
                 logger.Warn("Bar");
-                Assert.Equal("WARN NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
+                Application.DoEvents();
+                Assert.Equal("Warn NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
                 logger.Info("Test");
-                Assert.Equal("INFO NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text);
+                Application.DoEvents();
+                Assert.Equal("Info NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text);
                 logger.Debug("Foo");
-                Assert.Equal("DEBUG NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
+                Application.DoEvents();
+                Assert.Equal("Debug NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
                 logger.Trace("Bar");
+                Application.DoEvents();
                 Assert.Equal("Trace NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
+
             }
             finally
             {
+                if (testForm != null)
+                {
+                    testForm.Dispose();
+                }
                 LogManager.Configuration = null;
             }
         }

--- a/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
+++ b/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace NLog.Windows.Forms.Tests
 {
+    [Collection("NLog.Windows.Forms Tests")]
     public class ToolStripItemTargetTests
     {
         private Logger logger = LogManager.GetLogger("NLog.UnitTests.Targets.ToolStripItemTargetTests");
@@ -34,34 +35,28 @@ namespace NLog.Windows.Forms.Tests
                 SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
 
                 logger.Fatal("Test");   // Send log
-                while (target.IsWaiting()) // Do events until the invoked method is completed.
-                    Application.DoEvents(); 
-                Assert.Equal("Fatal NLog.UnitTests.Targets.ToolStripItemTargetTests Test", getText(testForm, testItem)); // Test if method worked.
+                Application.DoEvents(); // Do events to allow the invoked method is completed.
+                Assert.Equal("Fatal NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text); // Test if method worked.
                 
                 logger.Error("Foo");
-                while (target.IsWaiting()) // Do events until the invoked method is completed.
-                    Application.DoEvents();
-                Assert.Equal("Error NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", getText(testForm, testItem));
+                Application.DoEvents();
+                Assert.Equal("Error NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
                 
                 logger.Warn("Bar");
-                while (target.IsWaiting()) // Do events until the invoked method is completed.
-                    Application.DoEvents();
-                Assert.Equal("Warn NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", getText(testForm, testItem));
+                Application.DoEvents();
+                Assert.Equal("Warn NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
                 
                 logger.Info("Test");
-                while (target.IsWaiting()) // Do events until the invoked method is completed.
-                    Application.DoEvents();
-                Assert.Equal("Info NLog.UnitTests.Targets.ToolStripItemTargetTests Test", getText(testForm, testItem));
+                Application.DoEvents();
+                Assert.Equal("Info NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text);
                 
                 logger.Debug("Foo");
-                while (target.IsWaiting()) // Do events until the invoked method is completed.
-                    Application.DoEvents();
-                Assert.Equal("Debug NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", getText(testForm, testItem));
+                Application.DoEvents();
+                Assert.Equal("Debug NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
                 
                 logger.Trace("Bar");
-                while (target.IsWaiting()) // Do events until the invoked method is completed.
-                    Application.DoEvents(); 
-                Assert.Equal("Trace NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", getText(testForm, testItem));
+                Application.DoEvents();
+                Assert.Equal("Trace NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
 
             }
             finally

--- a/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
+++ b/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
@@ -17,19 +17,12 @@ namespace NLog.Windows.Forms.Tests
         public void SimpleToolStripItemTargetTest()
         {
             Form testForm = null;
+            ToolStripMenuItem testItem = null;
             try
             {
-                testForm = new Form();
-                testForm.Name = "Form1";
+                RunForm(out testForm,out testItem);
 
-
-                ToolStrip testMenuStrip = new ToolStrip();
-                testMenuStrip.Name = "ToolStrip1";
-                testForm.Controls.Add(testMenuStrip);
-
-                ToolStripMenuItem testItem = new ToolStripMenuItem();
-                testItem.Name = "Item1";
-                testMenuStrip.Items.Add(testItem);
+                Application.DoEvents();
 
                 ToolStripItemTarget target = new ToolStripItemTarget()
                 {
@@ -38,10 +31,6 @@ namespace NLog.Windows.Forms.Tests
                     ToolStripName = "ToolStrip1",
                     Layout = "${level} ${logger} ${message}"
                 };
-                testForm.Show();
-
-                Application.DoEvents();
-
                 SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
 
                 logger.Fatal("Test");
@@ -50,26 +39,21 @@ namespace NLog.Windows.Forms.Tests
                 
                 logger.Error("Foo");
                 Application.DoEvents();
-                Application.DoEvents();
                 Assert.Equal("Error NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
                 
                 logger.Warn("Bar");
-                Application.DoEvents();
                 Application.DoEvents();
                 Assert.Equal("Warn NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
                 
                 logger.Info("Test");
                 Application.DoEvents();
-                Application.DoEvents();
                 Assert.Equal("Info NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text);
                 
                 logger.Debug("Foo");
                 Application.DoEvents();
-                Application.DoEvents();
                 Assert.Equal("Debug NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
                 
                 logger.Trace("Bar");
-                Application.DoEvents();
                 Application.DoEvents();
                 Assert.Equal("Trace NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
 
@@ -82,6 +66,23 @@ namespace NLog.Windows.Forms.Tests
                 }
                 LogManager.Configuration = null;
             }
+        }
+
+        [STAThread]
+        private void RunForm(out Form testForm,out ToolStripMenuItem testItem)
+        {
+            testForm = new Form();
+            testForm.Name = "Form1";
+
+            ToolStrip testMenuStrip = new ToolStrip();
+            testMenuStrip.Name = "ToolStrip1";
+            testForm.Controls.Add(testMenuStrip);
+
+            testItem = new ToolStripMenuItem();
+            testItem.Name = "Item1";
+            testMenuStrip.Items.Add(testItem);
+
+            testForm.Show();
         }
     }
 }

--- a/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
+++ b/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
@@ -18,10 +18,20 @@ namespace NLog.Windows.Forms.Tests
         public void SimpleToolStripItemTargetTest()
         {
             Form testForm = null;
-            ToolStripMenuItem testItem = null;
             try
             {
-                RunForm(out testForm,out testItem);
+                testForm = new Form();
+                testForm.Name = "Form1";
+
+                ToolStrip testMenuStrip = new ToolStrip();
+                testMenuStrip.Name = "ToolStrip1";
+                testForm.Controls.Add(testMenuStrip);
+
+                ToolStripMenuItem testItem = new ToolStripMenuItem();
+                testItem.Name = "Item1";
+                testMenuStrip.Items.Add(testItem);
+
+                testForm.Show();
 
                 Application.DoEvents();
 
@@ -67,28 +77,6 @@ namespace NLog.Windows.Forms.Tests
                 }
                 LogManager.Configuration = null;
             }
-        }
-
-        private string getText(Form testForm, ToolStripMenuItem testItem)
-        {
-            return (string)testForm.Invoke((Func<string>)(()=> testItem.Text));
-        }
-
-        [STAThread]
-        private void RunForm(out Form testForm,out ToolStripMenuItem testItem)
-        {
-            testForm = new Form();
-            testForm.Name = "Form1";
-
-            ToolStrip testMenuStrip = new ToolStrip();
-            testMenuStrip.Name = "ToolStrip1";
-            testForm.Controls.Add(testMenuStrip);
-
-            testItem = new ToolStripMenuItem();
-            testItem.Name = "Item1";
-            testMenuStrip.Items.Add(testItem);
-
-            testForm.Show();
         }
     }
 }

--- a/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
+++ b/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
@@ -47,18 +47,24 @@ namespace NLog.Windows.Forms.Tests
                 logger.Fatal("Test");
                 Application.DoEvents();
                 Assert.Equal("Fatal NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text);
+                
                 logger.Error("Foo");
                 Application.DoEvents();
+                Application.DoEvents();
                 Assert.Equal("Error NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
+                
                 logger.Warn("Bar");
                 Application.DoEvents();
                 Assert.Equal("Warn NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
+                
                 logger.Info("Test");
                 Application.DoEvents();
                 Assert.Equal("Info NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text);
+                
                 logger.Debug("Foo");
                 Application.DoEvents();
                 Assert.Equal("Debug NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
+                
                 logger.Trace("Bar");
                 Application.DoEvents();
                 Assert.Equal("Trace NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);

--- a/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
+++ b/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
@@ -1,0 +1,65 @@
+﻿using NLog.Config;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Xunit;
+
+namespace NLog.Windows.Forms.Tests
+{
+    public class ToolStripItemTargetTests
+    {
+        private Logger logger = LogManager.GetLogger("NLog.UnitTests.Targets.ToolStripItemTargetTests");
+
+        [Fact]
+        public void SimpleToolStripItemTargetTest()
+        {
+            try
+            {
+                Form testForm = new Form();
+                testForm.Name = "Form1";
+
+
+                ToolStrip testMenuStrip = new ToolStrip();
+                testMenuStrip.Name = "ToolStrip1";
+                testForm.Controls.Add(testMenuStrip);
+
+                ToolStripMenuItem testItem = new ToolStripMenuItem();
+                testItem.Name = "Item1";
+                testMenuStrip.Items.Add(testItem);
+
+                ToolStripItemTarget target = new ToolStripItemTarget()
+                {
+                    ItemName = "Item1",
+                    FormName = "Form1",
+                    ToolStripName = "ToolStrip1",
+                    Layout = "${level} ${logger} ${message}"
+                };
+                testForm.Show();
+
+                Application.DoEvents();
+
+                SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
+
+                logger.Fatal("Test");
+                Assert.Equal("FATAL NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text);
+                logger.Error("Foo");
+                Assert.Equal("ERROR NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
+                logger.Warn("Bar");
+                Assert.Equal("WARN NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
+                logger.Info("Test");
+                Assert.Equal("INFO NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text);
+                logger.Debug("Foo");
+                Assert.Equal("DEBUG NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
+                logger.Trace("Bar");
+                Assert.Equal("Trace NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
+            }
+            finally
+            {
+                LogManager.Configuration = null;
+            }
+        }
+    }
+}

--- a/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
+++ b/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
@@ -55,17 +55,21 @@ namespace NLog.Windows.Forms.Tests
                 
                 logger.Warn("Bar");
                 Application.DoEvents();
+                Application.DoEvents();
                 Assert.Equal("Warn NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
                 
                 logger.Info("Test");
+                Application.DoEvents();
                 Application.DoEvents();
                 Assert.Equal("Info NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text);
                 
                 logger.Debug("Foo");
                 Application.DoEvents();
+                Application.DoEvents();
                 Assert.Equal("Debug NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
                 
                 logger.Trace("Bar");
+                Application.DoEvents();
                 Application.DoEvents();
                 Assert.Equal("Trace NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
 

--- a/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
+++ b/NLog.Windows.Forms.Tests/ToolStripItemTargetTests.cs
@@ -36,32 +36,32 @@ namespace NLog.Windows.Forms.Tests
                 logger.Fatal("Test");   // Send log
                 while (target.IsWaiting()) // Do events until the invoked method is completed.
                     Application.DoEvents(); 
-                Assert.Equal("Fatal NLog.UnitTests.Targets.ToolStripItemTargetTests Test",testItem.Text); // Test if method worked.
+                Assert.Equal("Fatal NLog.UnitTests.Targets.ToolStripItemTargetTests Test", getText(testForm, testItem)); // Test if method worked.
                 
                 logger.Error("Foo");
                 while (target.IsWaiting()) // Do events until the invoked method is completed.
                     Application.DoEvents();
-                Assert.Equal("Error NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
+                Assert.Equal("Error NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", getText(testForm, testItem));
                 
                 logger.Warn("Bar");
                 while (target.IsWaiting()) // Do events until the invoked method is completed.
                     Application.DoEvents();
-                Assert.Equal("Warn NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
+                Assert.Equal("Warn NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", getText(testForm, testItem));
                 
                 logger.Info("Test");
                 while (target.IsWaiting()) // Do events until the invoked method is completed.
                     Application.DoEvents();
-                Assert.Equal("Info NLog.UnitTests.Targets.ToolStripItemTargetTests Test", testItem.Text);
+                Assert.Equal("Info NLog.UnitTests.Targets.ToolStripItemTargetTests Test", getText(testForm, testItem));
                 
                 logger.Debug("Foo");
                 while (target.IsWaiting()) // Do events until the invoked method is completed.
                     Application.DoEvents();
-                Assert.Equal("Debug NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", testItem.Text);
+                Assert.Equal("Debug NLog.UnitTests.Targets.ToolStripItemTargetTests Foo", getText(testForm, testItem));
                 
                 logger.Trace("Bar");
                 while (target.IsWaiting()) // Do events until the invoked method is completed.
-                    Application.DoEvents();
-                Assert.Equal("Trace NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", testItem.Text);
+                    Application.DoEvents(); 
+                Assert.Equal("Trace NLog.UnitTests.Targets.ToolStripItemTargetTests Bar", getText(testForm, testItem));
 
             }
             finally
@@ -72,6 +72,11 @@ namespace NLog.Windows.Forms.Tests
                 }
                 LogManager.Configuration = null;
             }
+        }
+
+        private string getText(Form testForm, ToolStripMenuItem testItem)
+        {
+            return (string)testForm.Invoke((Func<string>)(()=> testItem.Text));
         }
 
         [STAThread]

--- a/NLog.Windows.Forms/FormHelper.cs
+++ b/NLog.Windows.Forms/FormHelper.cs
@@ -56,6 +56,34 @@ namespace NLog.Windows.Forms
         }
 
         /// <summary>
+        /// Finds item within searchCollection it's contents drop down items.
+        /// </summary>
+        /// <param name="name">Name of the ToolStripItem</param>
+        /// <param name="searchCollection">Collection of ToolStripItem we are looking for the item in.</param>
+        /// <returns>A value of null of no item has been found.</returns>
+        internal static ToolStripItem FindToolStripItem(string name, ToolStripItemCollection searchCollection)
+        {
+            foreach (ToolStripItem childItem in searchCollection)
+            {
+                if(childItem.Name == name)
+                {
+                    return childItem;
+                }
+                if(childItem is ToolStripDropDownItem)
+                {
+                    ToolStripDropDownItem childDropDown = childItem as ToolStripDropDownItem;
+                    ToolStripItem foundItem = FindToolStripItem(name, childDropDown.DropDownItems);
+
+                    if (foundItem != null)
+                    {
+                        return foundItem;
+                    }
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
         /// Finds control of specified type embended on searchControl.
         /// </summary>
         /// <typeparam name="TControl">The type of the control.</typeparam>

--- a/NLog.Windows.Forms/ToolStripItemTarget.cs
+++ b/NLog.Windows.Forms/ToolStripItemTarget.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows.Forms;
+using NLog.Common;
+using NLog.Config;
+using NLog.Targets;
+
+namespace NLog.Windows.Forms
+{
+    /// <summary>
+    /// Logs text to Windows.Forms.ToolStripItem.Text property control of specified Name.
+    /// </summary>
+    /// <example>
+    /// <p>
+    /// To set up the target in the <a href="config.html">configuration file</a>, 
+    /// use the following syntax:
+    /// </p>
+    /// <code lang="XML" source="examples/targets/Configuration File/ToolStripItem/NLog.config" />
+    /// <p>
+    /// The result is:
+    /// </p>
+    /// <img src="examples/targets/Screenshots/ToolStripItem/ToolStripItem.gif" />
+    /// <p>
+    /// To set up the log target programmatically similar to above use code like this:
+    /// </p>
+    /// <code lang="C#" source="examples/targets/Configuration API/ToolStripItem/Form1.cs" />,
+    /// </example>
+    [Target("ToolStripItem")]
+    public sealed class ToolStripItemTarget : TargetWithLayout
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ToolStripItemTarget" /> class.
+        /// </summary>
+        /// <remarks>
+        /// The default value of the layout is: <code>${longdate}|${level:uppercase=true}|${logger}|${message}</code>
+        /// </remarks>
+        public ToolStripItemTarget()
+        {
+        }
+
+        private delegate void DelSendTheMessageToFormControl(ToolStripItem control, string logMessage);
+
+        /// <summary>
+        /// Gets or sets the name of the ToolStripItem to which NLog will log write log text.
+        /// </summary>
+        /// <docgen category='Form Options' order='10' />
+        [RequiredParameter]
+        public string ItemName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of ToolStrip that contains the ToolStripItem to which NLog will log write log text.
+        /// </summary>
+        /// <docgen category='Form Options' order='10' />
+        [RequiredParameter]
+        public string ToolStripName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the Form on which the ToolStrip is located.
+        /// </summary>
+        /// <docgen category='Form Options' order='10' />
+        public string FormName { get; set; }
+
+        /// <summary>
+        /// Log message to item.
+        /// </summary>
+        /// <param name="logEvent">
+        /// The logging event.
+        /// </param>
+        protected override void Write(LogEventInfo logEvent)
+        {
+            string logMessage = Layout.Render(logEvent);
+
+            FindItemAndSendTheMessage(logMessage);
+        }
+
+        private void FindItemAndSendTheMessage(string logMessage)
+        {
+            Form form = null;
+
+            if (Form.ActiveForm != null)
+            {
+                form = Form.ActiveForm;
+            }
+
+            if (Application.OpenForms[FormName] != null)
+            {
+                form = Application.OpenForms[FormName];
+            }
+
+            if (form == null)
+            {
+                InternalLogger.Info("Form {0} not found", FormName);
+                return;
+            }
+
+            Control control = FormHelper.FindControl(ToolStripName, form);
+
+            if (control == null || !(control is ToolStrip))
+            {
+                InternalLogger.Info("ToolStrip {0} on Form {1} not found", ToolStripName, FormName);
+                return;
+            }
+
+            ToolStrip toolStrip = control as ToolStrip;
+
+            ToolStripItem item = FormHelper.FindToolStripItem(ItemName, toolStrip.Items);
+
+            if(item == null)
+            {
+                InternalLogger.Info("ToolStripItem {0} on ToolStrip {1} not found", ItemName, ToolStripName);
+                return;
+            }
+
+            try
+            {
+                control.BeginInvoke(new DelSendTheMessageToFormControl(SendTheMessageToFormControl), item, logMessage);
+            }
+            catch (Exception ex)
+            {
+                InternalLogger.Warn(ex.ToString());
+
+                if (LogManager.ThrowExceptions)
+                {
+                    throw;
+                }
+            }
+
+        }
+
+        private void SendTheMessageToFormControl(ToolStripItem item, string logMessage)
+        {
+            item.Text = logMessage;
+        }
+    }
+}

--- a/NLog.Windows.Forms/ToolStripItemTarget.cs
+++ b/NLog.Windows.Forms/ToolStripItemTarget.cs
@@ -29,6 +29,7 @@ namespace NLog.Windows.Forms
     [Target("ToolStripItem")]
     public sealed class ToolStripItemTarget : TargetWithLayout
     {
+        private IAsyncResult currentOperation;
         /// <summary>
         /// Initializes a new instance of the <see cref="ToolStripItemTarget" /> class.
         /// </summary>
@@ -37,6 +38,15 @@ namespace NLog.Windows.Forms
         /// </remarks>
         public ToolStripItemTarget()
         {
+        }
+
+        /// <summary>
+        /// Determine if there are any pending invoked operations.
+        /// </summary>
+        /// <returns>True if there is a pending invoke operation.</returns>
+        public bool IsWaiting()
+        {
+            return currentOperation != null && !currentOperation.IsCompleted;
         }
 
         private delegate void DelSendTheMessageToFormControl(ToolStripItem control, string logMessage);
@@ -109,7 +119,8 @@ namespace NLog.Windows.Forms
 
             try
             {
-                control.BeginInvoke(new DelSendTheMessageToFormControl(SendTheMessageToFormControl), item, logMessage);
+                currentOperation = control.BeginInvoke(new DelSendTheMessageToFormControl(SendTheMessageToFormControl), item, logMessage);
+                
             }
             catch (Exception ex)
             {

--- a/NLog.Windows.Forms/ToolStripItemTarget.cs
+++ b/NLog.Windows.Forms/ToolStripItemTarget.cs
@@ -29,7 +29,6 @@ namespace NLog.Windows.Forms
     [Target("ToolStripItem")]
     public sealed class ToolStripItemTarget : TargetWithLayout
     {
-        private IAsyncResult currentOperation;
         /// <summary>
         /// Initializes a new instance of the <see cref="ToolStripItemTarget" /> class.
         /// </summary>
@@ -38,15 +37,6 @@ namespace NLog.Windows.Forms
         /// </remarks>
         public ToolStripItemTarget()
         {
-        }
-
-        /// <summary>
-        /// Determine if there are any pending invoked operations.
-        /// </summary>
-        /// <returns>True if there is a pending invoke operation.</returns>
-        public bool IsWaiting()
-        {
-            return currentOperation != null && !currentOperation.IsCompleted;
         }
 
         private delegate void DelSendTheMessageToFormControl(ToolStripItem control, string logMessage);
@@ -119,7 +109,7 @@ namespace NLog.Windows.Forms
 
             try
             {
-                currentOperation = control.BeginInvoke(new DelSendTheMessageToFormControl(SendTheMessageToFormControl), item, logMessage);
+                control.BeginInvoke(new DelSendTheMessageToFormControl(SendTheMessageToFormControl), item, logMessage);
                 
             }
             catch (Exception ex)

--- a/NLog.Windows.Forms/ToolStripItemTarget.cs
+++ b/NLog.Windows.Forms/ToolStripItemTarget.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Windows.Forms;
 using NLog.Common;
 using NLog.Config;
+using NLog.Layouts;
 using NLog.Targets;
 
 namespace NLog.Windows.Forms
@@ -45,20 +46,20 @@ namespace NLog.Windows.Forms
         /// </summary>
         /// <docgen category='Form Options' order='10' />
         [RequiredParameter]
-        public string ItemName { get; set; }
+        public Layout ItemName { get; set; }
 
         /// <summary>
         /// Gets or sets the name of ToolStrip that contains the ToolStripItem to which NLog will log write log text.
         /// </summary>
         /// <docgen category='Form Options' order='10' />
         [RequiredParameter]
-        public string ToolStripName { get; set; }
+        public Layout ToolStripName { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the Form on which the ToolStrip is located.
         /// </summary>
         /// <docgen category='Form Options' order='10' />
-        public string FormName { get; set; }
+        public Layout FormName { get; set; }
 
         /// <summary>
         /// Log message to item.
@@ -70,11 +71,6 @@ namespace NLog.Windows.Forms
         {
             string logMessage = Layout.Render(logEvent);
 
-            FindItemAndSendTheMessage(logMessage);
-        }
-
-        private void FindItemAndSendTheMessage(string logMessage)
-        {
             Form form = null;
 
             if (Form.ActiveForm != null)
@@ -82,9 +78,9 @@ namespace NLog.Windows.Forms
                 form = Form.ActiveForm;
             }
 
-            if (Application.OpenForms[FormName] != null)
+            if (Application.OpenForms[FormName.Render(logEvent)] != null)
             {
-                form = Application.OpenForms[FormName];
+                form = Application.OpenForms[FormName.Render(logEvent)];
             }
 
             if (form == null)
@@ -93,7 +89,7 @@ namespace NLog.Windows.Forms
                 return;
             }
 
-            Control control = FormHelper.FindControl(ToolStripName, form);
+            Control control = FormHelper.FindControl(ToolStripName.Render(logEvent), form);
 
             if (control == null || !(control is ToolStrip))
             {
@@ -103,9 +99,9 @@ namespace NLog.Windows.Forms
 
             ToolStrip toolStrip = control as ToolStrip;
 
-            ToolStripItem item = FormHelper.FindToolStripItem(ItemName, toolStrip.Items);
+            ToolStripItem item = FormHelper.FindToolStripItem(ItemName.Render(logEvent), toolStrip.Items);
 
-            if(item == null)
+            if (item == null)
             {
                 InternalLogger.Info("ToolStripItem {0} on ToolStrip {1} not found", ItemName, ToolStripName);
                 return;
@@ -124,9 +120,7 @@ namespace NLog.Windows.Forms
                     throw;
                 }
             }
-
         }
-
         private void SendTheMessageToFormControl(ToolStripItem item, string logMessage)
         {
             item.Text = logMessage;


### PR DESCRIPTION
After encountering NLog main project "bug" [#147](https://github.com/NLog/NLog/issues/147). I implemented a target capable of logging to a ToolStripItem. The documentation is in the main project under pull request [#4566](https://github.com/NLog/NLog/pull/4566)