### PR TITLE
Fixed obsolete warning in MessageBoxTarget that blocks for NLog 5

### DIFF
--- a/NLog.Windows.Forms/MessageBoxTarget.cs
+++ b/NLog.Windows.Forms/MessageBoxTarget.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Windows.Forms;
 using NLog.Common;
@@ -65,7 +66,7 @@ namespace NLog.Windows.Forms
         {
             try
             {
-                MessageBox.Show(this.Layout.Render(logEvent), this.Caption.Render(logEvent));
+                MessageBox.Show(RenderLogEvent(this.Layout, logEvent), RenderLogEvent(this.Caption, logEvent));
             }
             catch (Exception ex)
             {
@@ -85,26 +86,25 @@ namespace NLog.Windows.Forms
         /// </summary>
         /// <param name="logEvents">The array of logging events.</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1300:SpecifyMessageBoxOptions",
-            Justification = "This is just debugging output.")]
-        [Obsolete("Instead override Write(IList<AsyncLogEventInfo> logEvents. Marked obsolete on NLog 4.5")]
-        protected override void Write(AsyncLogEventInfo[] logEvents)
+    Justification = "This is just debugging output.")]
+        protected override void Write(IList<AsyncLogEventInfo> logEvents)
         {
-            if (logEvents.Length == 0)
+            if (logEvents.Count == 0)
             {
                 return;
             }
 
             var sb = new StringBuilder();
-            var lastLogEvent = logEvents[logEvents.Length - 1];
+            var lastLogEvent = logEvents[logEvents.Count - 1];
             foreach (var ev in logEvents)
             {
-                sb.Append(this.Layout.Render(ev.LogEvent));
+                sb.Append(RenderLogEvent(this.Layout, ev.LogEvent));
                 sb.Append("\n");
             }
 
-            MessageBox.Show(sb.ToString(), this.Caption.Render(lastLogEvent.LogEvent));
+            MessageBox.Show(sb.ToString(), RenderLogEvent(this.Caption, lastLogEvent.LogEvent));
 
-            for (int i = 0; i < logEvents.Length; ++i)
+            for (int i = 0; i < logEvents.Count; ++i)
             {
                 logEvents[i].Continuation(null);
             }

--- a/NLog.Windows.Forms/NLog.Windows.Forms.csproj
+++ b/NLog.Windows.Forms/NLog.Windows.Forms.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net35;netcoreapp3.1;net5.0-windows</TargetFrameworks>
     <AssemblyTitle>NLog.Windows.Forms</AssemblyTitle>
@@ -12,7 +12,7 @@
     <PackageIcon>N.png</PackageIcon>
     <PackageId>NLog.Windows.Forms</PackageId>
     <PackageProjectUrl>https://nlog-project.org</PackageProjectUrl>
-    <PackageTags>nlog target forms windows richtextbox</PackageTags>
+    <PackageTags>nlog target forms windows richtextbox winforms</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <DebugType Condition=" '$(Configuration)' == 'Debug' ">Full</DebugType>
@@ -26,7 +26,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
 
     <PackageReleaseNotes>
-Added support for .NET Core 3.1 and .NET 5 (#42) (@weltkante, @304NotModified)
+Fixed obsolete warning in MessageBoxTarget that blocks NLog 5
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 4.5.0.{build}
+version: 4.6.0.{build}
 image: Visual Studio 2019
 clone_folder: c:\projects\nlog
 configuration: Release

--- a/build.ps1
+++ b/build.ps1
@@ -2,7 +2,7 @@
 # creates NuGet package at \artifacts
 dotnet --version
 
-$versionPrefix = "4.5.0" # Also update version for minor versions in appveyor.yml 
+$versionPrefix = "4.6.0" # Also update version for minor versions in appveyor.yml 
 $versionSuffix = ""
 $versionFile = $versionPrefix + "." + ${env:APPVEYOR_BUILD_NUMBER}
 if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {


### PR DESCRIPTION
Make NLog.Windows.Forms-build that supports both NLog4 + NLog5