### PR TITLE
Support Layoutable Properties

### DIFF
--- a/NLog.Windows.Forms.Tests/RichTextBoxTargetTests.cs
+++ b/NLog.Windows.Forms.Tests/RichTextBoxTargetTests.cs
@@ -386,8 +386,8 @@ namespace NLog.Windows.Forms.Tests
             Assert.Equal(expectedRules.Length, actualRules.Count);
             for (int i = 0; i < expectedRules.Length; ++i)
             {
-                Assert.Equal(expectedRules[i].BackgroundColor, actualRules[i].BackgroundColor);
-                Assert.Equal(expectedRules[i].FontColor, actualRules[i].FontColor);
+                Assert.Equal(expectedRules[i].BackgroundColor.ToString(), actualRules[i].BackgroundColor.ToString());
+                Assert.Equal(expectedRules[i].FontColor.ToString(), actualRules[i].FontColor.ToString());
                 Assert.Equal(expectedRules[i].Condition.ToString(), actualRules[i].Condition.ToString());
                 Assert.Equal(expectedRules[i].Style, actualRules[i].Style);
             }

--- a/NLog.Windows.Forms/Targets/FormControlTarget.cs
+++ b/NLog.Windows.Forms/Targets/FormControlTarget.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Windows.Forms;
 using NLog.Common;
 using NLog.Config;
+using NLog.Layouts;
 using NLog.Targets;
 
 namespace NLog.Windows.Forms.Targets
@@ -46,7 +47,7 @@ namespace NLog.Windows.Forms.Targets
         /// </summary>
         /// <docgen category='Form Options' order='10' />
         [RequiredParameter]
-        public string ControlName { get; set; }
+        public Layout ControlName { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether log text should be appended to the text of the control instead of overwriting it. </summary>
@@ -58,7 +59,7 @@ namespace NLog.Windows.Forms.Targets
         /// Gets or sets the name of the Form on which the control is located.
         /// </summary>
         /// <docgen category='Form Options' order='10' />
-        public string FormName { get; set; }
+        public Layout FormName { get; set; }
 
         /// <summary>
         /// Gets or sets whether new log entry are added to the start or the end of the control
@@ -75,11 +76,6 @@ namespace NLog.Windows.Forms.Targets
         {
             string logMessage = Layout.Render(logEvent);
 
-            FindControlAndSendTheMessage(logMessage);
-        }
-
-        private void FindControlAndSendTheMessage(string logMessage)
-        {
             Form form = null;
 
             if (Form.ActiveForm != null)
@@ -87,9 +83,9 @@ namespace NLog.Windows.Forms.Targets
                 form = Form.ActiveForm;
             }
 
-            if (Application.OpenForms[FormName] != null)
+            if (Application.OpenForms[FormName.Render(logEvent)] != null)
             {
-                form = Application.OpenForms[FormName];
+                form = Application.OpenForms[FormName.Render(logEvent)];
             }
 
             if (form == null)
@@ -98,7 +94,7 @@ namespace NLog.Windows.Forms.Targets
                 return;
             }
 
-            Control control = FormHelper.FindControl(ControlName, form);
+            Control control = FormHelper.FindControl(ControlName.Render(logEvent), form);
 
             if (control == null)
             {
@@ -118,7 +114,6 @@ namespace NLog.Windows.Forms.Targets
                     throw;
                 }
             }
-
         }
 
         private void SendTheMessageToFormControl(Control control, string logMessage)

--- a/NLog.Windows.Forms/Targets/FormControlTarget.cs
+++ b/NLog.Windows.Forms/Targets/FormControlTarget.cs
@@ -74,7 +74,7 @@ namespace NLog.Windows.Forms.Targets
         /// </param>
         protected override void Write(LogEventInfo logEvent)
         {
-            string logMessage = Layout.Render(logEvent);
+            string logMessage = RenderLogEvent(Layout, logEvent);
 
             Form form = null;
 
@@ -82,7 +82,7 @@ namespace NLog.Windows.Forms.Targets
             {
                 form = Form.ActiveForm;
             }
-            string renderedFormName = FormName.Render(logEvent);
+            string renderedFormName = RenderLogEvent(FormName, logEvent);
             if (Application.OpenForms[renderedFormName] != null)
             {
                 form = Application.OpenForms[renderedFormName];
@@ -94,7 +94,7 @@ namespace NLog.Windows.Forms.Targets
                 return;
             }
 
-            Control control = FormHelper.FindControl(ControlName.Render(logEvent), form);
+            Control control = FormHelper.FindControl(RenderLogEvent(ControlName, logEvent), form);
 
             if (control == null)
             {

--- a/NLog.Windows.Forms/Targets/FormControlTarget.cs
+++ b/NLog.Windows.Forms/Targets/FormControlTarget.cs
@@ -82,10 +82,10 @@ namespace NLog.Windows.Forms.Targets
             {
                 form = Form.ActiveForm;
             }
-
-            if (Application.OpenForms[FormName.Render(logEvent)] != null)
+            string renderedFormName = FormName.Render(logEvent);
+            if (Application.OpenForms[renderedFormName] != null)
             {
-                form = Application.OpenForms[FormName.Render(logEvent)];
+                form = Application.OpenForms[renderedFormName];
             }
 
             if (form == null)

--- a/NLog.Windows.Forms/Targets/RichTextBoxRowColoringRule.cs
+++ b/NLog.Windows.Forms/Targets/RichTextBoxRowColoringRule.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 using NLog.Conditions;
 using NLog.Config;
+using NLog.Layouts;
 
 namespace NLog.Windows.Forms.Targets
 {
@@ -38,7 +39,7 @@ namespace NLog.Windows.Forms.Targets
         /// </remarks>
         /// <docgen category="Formatting Options" order="10"/>
         [DefaultValue("Empty")]
-        public string FontColor { get; set; }
+        public Layout FontColor { get; set; }
 
         /// <summary>
         /// Gets or sets the background color.
@@ -51,7 +52,7 @@ namespace NLog.Windows.Forms.Targets
         /// </remarks>
         /// <docgen category="Formatting Options" order="10"/>
         [DefaultValue("Empty")]
-        public string BackgroundColor { get; set; }
+        public Layout BackgroundColor { get; set; }
 
         /// <summary>
         /// Gets or sets the font style of matched text.

--- a/NLog.Windows.Forms/Targets/RichTextBoxRowColoringRule.cs
+++ b/NLog.Windows.Forms/Targets/RichTextBoxRowColoringRule.cs
@@ -91,8 +91,8 @@ namespace NLog.Windows.Forms.Targets
         public RichTextBoxRowColoringRule(string condition, string fontColor, string backColor, FontStyle fontStyle)
         {
             this.Condition = (ConditionExpression)condition;
-            this.FontColor = fontColor;
-            this.BackgroundColor = backColor;
+            this.FontColor = Layout.FromString(fontColor);
+            this.BackgroundColor = Layout.FromString(backColor);
             this.Style = fontStyle;
         }
 
@@ -104,8 +104,8 @@ namespace NLog.Windows.Forms.Targets
         public RichTextBoxRowColoringRule(string condition, string fontColor, string backColor)
         {
             this.Condition = (ConditionExpression)condition;
-            this.FontColor = fontColor;
-            this.BackgroundColor = backColor;
+            this.FontColor = Layout.FromString(fontColor);
+            this.BackgroundColor = Layout.FromString(backColor);
             this.Style = FontStyle.Regular;
         }
 

--- a/NLog.Windows.Forms/Targets/RichTextBoxTarget.cs
+++ b/NLog.Windows.Forms/Targets/RichTextBoxTarget.cs
@@ -766,7 +766,7 @@ namespace NLog.Windows.Forms.Targets
                 }
             }
 
-            string logMessage = Layout.Render(logEvent);
+            string logMessage = RenderLogEvent(Layout, logEvent);
             RichTextBoxRowColoringRule matchingRule = FindMatchingRule(logEvent);
 
             bool messageSent = DoSendMessageToTextbox(logMessage, matchingRule, logEvent);
@@ -882,8 +882,8 @@ namespace NLog.Windows.Forms.Targets
 
             int startIndex = textBox.TextLength;
             textBox.SelectionStart = startIndex;
-            textBox.SelectionBackColor = GetColorFromString(rule.BackgroundColor.Render(logEvent), textBox.BackColor);
-            textBox.SelectionColor = GetColorFromString(rule.FontColor.Render(logEvent), textBox.ForeColor);
+            textBox.SelectionBackColor = GetColorFromString(RenderLogEvent(rule.BackgroundColor, logEvent), textBox.BackColor);
+            textBox.SelectionColor = GetColorFromString(RenderLogEvent(rule.FontColor, logEvent), textBox.ForeColor);
             textBox.SelectionFont = new Font(textBox.SelectionFont, textBox.SelectionFont.Style ^ rule.Style);
             textBox.AppendText(logMessage + "\n");
             textBox.SelectionLength = textBox.TextLength - textBox.SelectionStart;
@@ -896,8 +896,8 @@ namespace NLog.Windows.Forms.Targets
                 {
                     textBox.SelectionStart = match.Index;
                     textBox.SelectionLength = match.Length;
-                    textBox.SelectionBackColor = GetColorFromString(wordRule.BackgroundColor.Render(logEvent), textBox.BackColor);
-                    textBox.SelectionColor = GetColorFromString(wordRule.FontColor.Render(logEvent), textBox.ForeColor);
+                    textBox.SelectionBackColor = GetColorFromString(RenderLogEvent(wordRule.BackgroundColor, logEvent), textBox.BackColor);
+                    textBox.SelectionColor = GetColorFromString(RenderLogEvent(wordRule.FontColor, logEvent), textBox.ForeColor);
                     textBox.SelectionFont = new Font(textBox.SelectionFont, textBox.SelectionFont.Style ^ wordRule.Style);
                 }
             }

--- a/NLog.Windows.Forms/Targets/RichTextBoxTarget.cs
+++ b/NLog.Windows.Forms/Targets/RichTextBoxTarget.cs
@@ -882,8 +882,8 @@ namespace NLog.Windows.Forms.Targets
 
             int startIndex = textBox.TextLength;
             textBox.SelectionStart = startIndex;
-            textBox.SelectionBackColor = GetColorFromString(rule.BackgroundColor, textBox.BackColor);
-            textBox.SelectionColor = GetColorFromString(rule.FontColor, textBox.ForeColor);
+            textBox.SelectionBackColor = GetColorFromString(rule.BackgroundColor.Render(logEvent), textBox.BackColor);
+            textBox.SelectionColor = GetColorFromString(rule.FontColor.Render(logEvent), textBox.ForeColor);
             textBox.SelectionFont = new Font(textBox.SelectionFont, textBox.SelectionFont.Style ^ rule.Style);
             textBox.AppendText(logMessage + "\n");
             textBox.SelectionLength = textBox.TextLength - textBox.SelectionStart;
@@ -891,7 +891,7 @@ namespace NLog.Windows.Forms.Targets
             // find word to color
             foreach (RichTextBoxWordColoringRule wordRule in WordColoringRules)
             {
-                MatchCollection matches = wordRule.CompiledRegex.Matches(textBox.Text, startIndex);
+                MatchCollection matches = wordRule.CompileRegex(logEvent).Matches(textBox.Text, startIndex);
                 foreach (Match match in matches)
                 {
                     textBox.SelectionStart = match.Index;

--- a/NLog.Windows.Forms/Targets/RichTextBoxTarget.cs
+++ b/NLog.Windows.Forms/Targets/RichTextBoxTarget.cs
@@ -896,8 +896,8 @@ namespace NLog.Windows.Forms.Targets
                 {
                     textBox.SelectionStart = match.Index;
                     textBox.SelectionLength = match.Length;
-                    textBox.SelectionBackColor = GetColorFromString(wordRule.BackgroundColor, textBox.BackColor);
-                    textBox.SelectionColor = GetColorFromString(wordRule.FontColor, textBox.ForeColor);
+                    textBox.SelectionBackColor = GetColorFromString(wordRule.BackgroundColor.Render(logEvent), textBox.BackColor);
+                    textBox.SelectionColor = GetColorFromString(wordRule.FontColor.Render(logEvent), textBox.ForeColor);
                     textBox.SelectionFont = new Font(textBox.SelectionFont, textBox.SelectionFont.Style ^ wordRule.Style);
                 }
             }

--- a/NLog.Windows.Forms/Targets/RichTextBoxWordColoringRule.cs
+++ b/NLog.Windows.Forms/Targets/RichTextBoxWordColoringRule.cs
@@ -61,7 +61,7 @@ namespace NLog.Windows.Forms.Targets
         {
                 if (this.compiledRegex == null)
                 {
-                    string pattern = this.Regex.Render(logEvent);
+                    string pattern = this.Regex == null? null: this.Regex.Render(logEvent);
                     if (pattern == null && this.Text != null)
                     {
                         pattern = System.Text.RegularExpressions.Regex.Escape(this.Text.Render(logEvent));
@@ -84,7 +84,7 @@ namespace NLog.Windows.Forms.Targets
         /// </summary>
         /// <docgen category="Formatting Options" order="10"/>
         [DefaultValue("Empty")]
-        public string FontColor { get; set; }
+        public Layout FontColor { get; set; }
 
         /// <summary>
         /// Gets or sets the background color.
@@ -93,7 +93,7 @@ namespace NLog.Windows.Forms.Targets
         /// </summary>
         /// <docgen category="Formatting Options" order="10"/>
         [DefaultValue("Empty")]
-        public string BackgroundColor { get; set; }
+        public Layout BackgroundColor { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:NLog.Targets.RichTextBoxWordColoringRule"/> class.
@@ -113,8 +113,8 @@ namespace NLog.Windows.Forms.Targets
         public RichTextBoxWordColoringRule(string text, string fontColor, string backgroundColor)
         {
             this.Text = text;
-            this.FontColor = fontColor;
-            this.BackgroundColor = backgroundColor;
+            this.FontColor = Layout.FromString(fontColor);
+            this.BackgroundColor = Layout.FromString(backgroundColor);
         }
 
         /// <summary>
@@ -125,8 +125,8 @@ namespace NLog.Windows.Forms.Targets
         public RichTextBoxWordColoringRule(string text, string textColor, string backgroundColor, FontStyle fontStyle)
         {
             this.Text = text;
-            this.FontColor = textColor;
-            this.BackgroundColor = backgroundColor;
+            this.FontColor = Layout.FromString(textColor);
+            this.BackgroundColor = Layout.FromString(backgroundColor);
             this.Style = fontStyle;
         }
     }

--- a/NLog.Windows.Forms/Targets/RichTextBoxWordColoringRule.cs
+++ b/NLog.Windows.Forms/Targets/RichTextBoxWordColoringRule.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 using System.Text.RegularExpressions;
 using NLog.Config;
+using NLog.Layouts;
 
 namespace NLog.Windows.Forms.Targets
 {
@@ -19,14 +20,14 @@ namespace NLog.Windows.Forms.Targets
         /// 
         /// </summary>
         /// <docgen category="Rule Matching Options" order="10"/>
-        public string Regex { get; set; }
+        public Layout Regex { get; set; }
 
         /// <summary>
         /// Gets or sets the text to be matched. You must specify either <c>text</c> or <c>regex</c>.
         /// 
         /// </summary>
         /// <docgen category="Rule Matching Options" order="10"/>
-        public string Text { get; set; }
+        public Layout Text { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to match whole words only.
@@ -56,16 +57,14 @@ namespace NLog.Windows.Forms.Targets
         /// Gets the compiled regular expression that matches either Text or Regex property.
         /// 
         /// </summary>
-        public Regex CompiledRegex
+        public Regex CompileRegex(LogEventInfo logEvent)
         {
-            get
-            {
                 if (this.compiledRegex == null)
                 {
-                    string pattern = this.Regex;
+                    string pattern = this.Regex.Render(logEvent);
                     if (pattern == null && this.Text != null)
                     {
-                        pattern = System.Text.RegularExpressions.Regex.Escape(this.Text);
+                        pattern = System.Text.RegularExpressions.Regex.Escape(this.Text.Render(logEvent));
                         if (this.WholeWords)
                             pattern = "\b" + pattern + "\b";
                     }
@@ -75,7 +74,7 @@ namespace NLog.Windows.Forms.Targets
                     this.compiledRegex = new Regex(pattern, options);
                 }
                 return this.compiledRegex;
-            }
+            
         }
 
         /// <summary>

--- a/NLog.Windows.Forms/Targets/RichTextBoxWordColoringRule.cs
+++ b/NLog.Windows.Forms/Targets/RichTextBoxWordColoringRule.cs
@@ -13,8 +13,6 @@ namespace NLog.Windows.Forms.Targets
     [NLogConfigurationItem]
     public class RichTextBoxWordColoringRule
     {
-        private Regex compiledRegex;
-
         /// <summary>
         /// Gets or sets the regular expression to be matched. You must specify either <c>text</c> or <c>regex</c>.
         /// 
@@ -59,22 +57,18 @@ namespace NLog.Windows.Forms.Targets
         /// </summary>
         public Regex CompileRegex(LogEventInfo logEvent)
         {
-                if (this.compiledRegex == null)
-                {
-                    string pattern = this.Regex == null? null: this.Regex.Render(logEvent);
-                    if (pattern == null && this.Text != null)
-                    {
-                        pattern = System.Text.RegularExpressions.Regex.Escape(this.Text.Render(logEvent));
-                        if (this.WholeWords)
-                            pattern = "\b" + pattern + "\b";
-                    }
-                    RegexOptions options = RegexOptions.Compiled;
-                    if (this.IgnoreCase)
-                        options |= RegexOptions.IgnoreCase;
-                    this.compiledRegex = new Regex(pattern, options);
-                }
-                return this.compiledRegex;
-            
+            string pattern = this.Regex == null? null: this.Regex.Render(logEvent);
+            if (pattern == null && this.Text != null)
+            {
+                pattern = System.Text.RegularExpressions.Regex.Escape(this.Text.Render(logEvent));
+                if (this.WholeWords)
+                    pattern = "\b" + pattern + "\b";
+            }
+            RegexOptions options = RegexOptions.Compiled;
+            if (this.IgnoreCase)
+                options |= RegexOptions.IgnoreCase;
+                
+            return new Regex(pattern, options);
         }
 
         /// <summary>

--- a/NLog.Windows.Forms/Targets/ToolStripItemTarget.cs
+++ b/NLog.Windows.Forms/Targets/ToolStripItemTarget.cs
@@ -68,7 +68,7 @@ namespace NLog.Windows.Forms.Targets
         /// </param>
         protected override void Write(LogEventInfo logEvent)
         {
-            string logMessage = Layout.Render(logEvent);
+            string logMessage = RenderLogEvent(Layout, logEvent);
 
             Form form = null;
 
@@ -77,7 +77,7 @@ namespace NLog.Windows.Forms.Targets
                 form = Form.ActiveForm;
             }
 
-            string renderedFormName = FormName.Render(logEvent);
+            string renderedFormName = RenderLogEvent(FormName, logEvent);
             if (Application.OpenForms[renderedFormName] != null)
             {
                 form = Application.OpenForms[renderedFormName];
@@ -89,7 +89,7 @@ namespace NLog.Windows.Forms.Targets
                 return;
             }
 
-            Control control = FormHelper.FindControl(ToolStripName.Render(logEvent), form);
+            Control control = FormHelper.FindControl(RenderLogEvent(ToolStripName, logEvent), form);
 
             if (control == null || !(control is ToolStrip))
             {
@@ -99,7 +99,7 @@ namespace NLog.Windows.Forms.Targets
 
             ToolStrip toolStrip = control as ToolStrip;
 
-            ToolStripItem item = FormHelper.FindToolStripItem(ItemName.Render(logEvent), toolStrip.Items);
+            ToolStripItem item = FormHelper.FindToolStripItem(RenderLogEvent(ItemName, logEvent), toolStrip.Items);
 
             if (item == null)
             {

--- a/NLog.Windows.Forms/Targets/ToolStripItemTarget.cs
+++ b/NLog.Windows.Forms/Targets/ToolStripItemTarget.cs
@@ -77,9 +77,10 @@ namespace NLog.Windows.Forms.Targets
                 form = Form.ActiveForm;
             }
 
-            if (Application.OpenForms[FormName.Render(logEvent)] != null)
+            string renderedFormName = FormName.Render(logEvent);
+            if (Application.OpenForms[renderedFormName] != null)
             {
-                form = Application.OpenForms[FormName.Render(logEvent)];
+                form = Application.OpenForms[renderedFormName];
             }
 
             if (form == null)


### PR DESCRIPTION
Make all properties layoutable as per issue #110.
FormName and ControlName of RichTextBoxTarget are still strings, see above referenced issue for more information.